### PR TITLE
Auto-Format

### DIFF
--- a/lib/windows-carriage-return-remover.coffee
+++ b/lib/windows-carriage-return-remover.coffee
@@ -1,6 +1,17 @@
 module.exports =
+  config:
+    formatOnSave:
+      type: 'boolean'
+      default: false
+      description: 'Remove carriage returns automatically on save'
   activate: ->
     atom.commands.add 'atom-workspace', "windows-carriage-return:remove": => @remove()
+    atom.workspace.observeTextEditors (editor) => @handleSave(editor)
   remove: ->
     editor = atom.workspace.getActivePaneItem()
     editor.setText(editor.getText().replace(/(\r\n|\n|\r)/gm,"\n"))
+  handleSave: (editor) ->
+    buffer = editor.getBuffer()
+    @subscription = buffer.onWillSave =>
+      if atom.config.get('windows-carriage-return-remover.formatOnSave') is true
+        @remove()


### PR DESCRIPTION
Added auto-format on save config item. Ref #3.

Currently auto-format is not turned on as soon as Atom loads, it only gets activated once the plugin is activated when Remove is called for the first time. I've looked at other plugins and can't figure out what to use to force the plugin to call `activate` on Atom load.
